### PR TITLE
Fix private field `ResonanceAudio.roomPosition' is assigned warning when building

### DIFF
--- a/platforms/unity/UnityIntegration/Assets/ResonanceAudio/Scripts/ResonanceAudio.cs
+++ b/platforms/unity/UnityIntegration/Assets/ResonanceAudio/Scripts/ResonanceAudio.cs
@@ -401,8 +401,10 @@ public static class ResonanceAudio {
   // Occlusion layer mask.
   private static int occlusionMaskValue = -1;
 
+#if UNITY_EDITOR
   // Pre-allocated position array for proxy room computation.
   private static float[] roomPosition = new float[3];
+#endif  // UNITY_EDITOR
 
   // Pre-allocated room properties instance for room effects computation.
   private static RoomProperties roomProperties = new RoomProperties();


### PR DESCRIPTION
Wrap editor only ResonanceAudio.roomPosition field in #if/#endif to avoid build time warning:

Assets/ResonanceAudio/Scripts/ResonanceAudio.cs(407,26): warning CS0414: The private field `ResonanceAudio.roomPosition' is assigned but its value is never used