### PR TITLE
AlignedAlloctor: fix C++20 build

### DIFF
--- a/resonance_audio/base/aligned_allocator.h
+++ b/resonance_audio/base/aligned_allocator.h
@@ -72,9 +72,9 @@ void AllignedFree(PointerType mem_block_aligned) {
 template <typename Type, size_t Alignment>
 class AlignedAllocator : public std::allocator<Type> {
  public:
-  typedef typename std::allocator<Type>::pointer Pointer;
-  typedef typename std::allocator<Type>::const_pointer ConstPointer;
-  typedef typename std::allocator<Type>::size_type SizeType;
+  using Pointer = typename std::allocator_traits<std::allocator<Type>>::pointer;
+  using ConstPointer = typename std::allocator_traits<std::allocator<Type>>::const_pointer;
+  using SizeType = typename std::allocator_traits<std::allocator<Type>>::size_type;
 
   AlignedAllocator() { StaticAlignmentCheck<sizeof(Type), Alignment>(); }
 


### PR DESCRIPTION
C++17 deprecated, and C++20 removed, the nested pointer, size_type
etc. typedefs in std::allocator. Since C++11, the way to get these
types is to go via allocator_traits, so do that.

This breaks compatibility with C++ < 11.

Fixes #61